### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ I strongly recommend to use [AndroidViewAnimations](https://github.com/daimajia/
 - [PagerSlidingTabStrip](https://github.com/astuetz/PagerSlidingTabStrip)
 - [AndroidViewAnimations](https://github.com/daimajia/AndroidViewAnimations)
 
-##Contact me
+## Contact me
 
 I love open source project, if you have a better idea on this project or way, please let me know, thanks:)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
